### PR TITLE
XamlX SreTypeSystem: Allow internal types

### DIFF
--- a/src/XamlX.IL.Cecil/XamlX.IL.Cecil.csproj
+++ b/src/XamlX.IL.Cecil/XamlX.IL.Cecil.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Mono.Cecil" Version="0.10.3" />
+      <PackageReference Include="Mono.Cecil" Version="0.11.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
(This draft is split over two repos. The engine part, which includes an explanation, is [here](https://github.com/space-wizards/RobustToolbox/pull/5406).)

Likely a prod-ready implementation of this would actually copy SreTypeSystem into a new RobustSreTypeSystem class inside the game code, because changing library internals is grody. But that would be a massively bloated change in comparison to this proof-of-concept.